### PR TITLE
fix(style): Update typography.com fonts css reference URL

### DIFF
--- a/index.hbs
+++ b/index.hbs
@@ -5,7 +5,7 @@
         <meta http-equiv="x-ua-compatible" content="ie=edge">
         <title>HSL</title>
         <meta name="viewport" content="width=device-width, initial-scale=1">
-        <link rel="stylesheet" href="https://cloud.typography.com/6364294/6653152/css/fonts.css">
+        <link rel="stylesheet" href="https://cloud.typography.com/6364294/7572592/css/fonts.css">
         <style>
             body {
                 width: 90%;


### PR DESCRIPTION
The typography.com fonts CSS URL is replaced with correct URL.